### PR TITLE
add libvtk6-qt-dev dependency to build on Debian Stretch

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,10 @@
   <build_depend>shape_msgs</build_depend>
   <build_depend>tf</build_depend>
 
+  <!-- Needed yo work around https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=894656 on Debian Stretch -->
+  <build_depend>libvtk6-qt-dev</build_depend>
+  <run_depend>libvtk6-qt-dev</run_depend>
+  
   <run_depend>actionlib</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>grasping_msgs</run_depend>


### PR DESCRIPTION
the `libpcl-dev` package is missing a dependency causing the `Qt5::Widgets` target to be exported but not satisfied.

This should fix the currently failing Stretch builds (e.g. http://build.ros.org/job/Lbin_ds_dS64__simple_grasping__debian_stretch_amd64__binary/1/)