### PR TITLE
continuous detection and default transform

### DIFF
--- a/src/basic_grasping_perception.cpp
+++ b/src/basic_grasping_perception.cpp
@@ -154,8 +154,8 @@ private:
       if (ros::Time::now() - t > ros::Duration(3.0))
       {
         find_objects_ = false;
-        server_->setAborted(result, "Failed to get camera data in alloted time.");
-        ROS_ERROR("Failed to get camera data in alloted time.");
+        server_->setAborted(result, "Failed to get camera data in allocated time.");
+        ROS_ERROR("Failed to get camera data in allocated time.");
         return;
       }
     }

--- a/src/basic_grasping_perception.cpp
+++ b/src/basic_grasping_perception.cpp
@@ -103,7 +103,7 @@ private:
     if (!find_objects_)
       return;
 
-    ROS_DEBUG("Cloud recieved with %d points.", static_cast<int>(cloud->points.size()));
+    ROS_DEBUG("Cloud received with %d points.", static_cast<int>(cloud->points.size()));
 
     // Filter out noisy long-range points
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_filtered(new pcl::PointCloud<pcl::PointXYZRGB>);

--- a/src/basic_grasping_perception.cpp
+++ b/src/basic_grasping_perception.cpp
@@ -58,6 +58,9 @@ public:
     // use_debug: enable/disable output of a cloud containing object points
     nh_.getParam("use_debug", debug_);
 
+    // optionally enable object detection from the beginning without need to call the action
+    nh_.param<bool>("continuous_detection", continuous_detection_, false);
+
     // frame_id: frame to transform cloud to (should be XY horizontal)
     world_frame_ = "base_link";
     nh_.getParam("frame_id", world_frame_);
@@ -100,7 +103,7 @@ private:
   void cloudCallback(const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& cloud)
   {
     // be lazy
-    if (!find_objects_)
+    if (!find_objects_ && !continuous_detection_)
       return;
 
     ROS_DEBUG("Cloud received with %d points.", static_cast<int>(cloud->points.size()));
@@ -186,6 +189,7 @@ private:
   std::string world_frame_;
 
   bool find_objects_;
+  bool continuous_detection_;
   std::vector<grasping_msgs::Object> objects_;
   std::vector<grasping_msgs::Object> supports_;
 

--- a/src/object_support_segmentation.cpp
+++ b/src/object_support_segmentation.cpp
@@ -86,8 +86,8 @@ bool ObjectSupportSegmentation::segment(
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_filtered(new pcl::PointCloud<pcl::PointXYZRGB>);
   voxel_grid_.setInputCloud(cloud);
   voxel_grid_.filter(*cloud_filtered);
-  ROS_DEBUG("object_support_segmentation",
-            "Filtered for transformed Z, now %d points.", static_cast<int>(cloud_filtered->points.size()));
+  ROS_DEBUG_NAMED("object_support_segmentation",
+                  "Filtered for transformed Z, now %d points.", static_cast<int>(cloud_filtered->points.size()));
 
   // remove support planes
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr non_horizontal_planes(new pcl::PointCloud<pcl::PointXYZRGB>);
@@ -103,7 +103,7 @@ bool ObjectSupportSegmentation::segment(
     segment_.segment(*inliers, *coefficients);
     if (inliers->indices.size() < (size_t) thresh)  // TODO: make configurable? TODO make this based on "can we grasp object"
     {
-      ROS_DEBUG("object_support_segmentation", "No more planes to remove.");
+      ROS_DEBUG_NAMED("object_support_segmentation", "No more planes to remove.");
       break;
     }
 
@@ -120,8 +120,8 @@ bool ObjectSupportSegmentation::segment(
     float angle = acos(Eigen::Vector3f::UnitZ().dot(normal));
     if (angle < 0.15)
     {
-      ROS_DEBUG("object_support_segmentation",
-                "Removing a plane with %d points.", static_cast<int>(inliers->indices.size()));
+      ROS_DEBUG_NAMED("object_support_segmentation",
+                      "Removing a plane with %d points.", static_cast<int>(inliers->indices.size()));
 
       // new support object, with cluster, bounding box, and plane
       grasping_msgs::Object object;
@@ -145,8 +145,8 @@ bool ObjectSupportSegmentation::segment(
 
       if (output_clouds)
       {
-        ROS_DEBUG("object_support_segmentation",
-                  "Adding support cluster of size %d.", static_cast<int>(plane.points.size()));
+        ROS_DEBUG_NAMED("object_support_segmentation",
+                        "Adding support cluster of size %d.", static_cast<int>(plane.points.size()));
         float hue = (360.0 / 8) * supports.size();
         colorizeCloud(plane, hue);
         support_cloud += plane;
@@ -158,8 +158,7 @@ bool ObjectSupportSegmentation::segment(
     else
     {
       // Add plane to temporary point cloud so we can recover points for object extraction below
-      ROS_DEBUG("object_support_segmentation",
-                "Plane is not horizontal");
+      ROS_DEBUG_NAMED("object_support_segmentation", "Plane is not horizontal");
       *non_horizontal_planes += plane;
     }
 
@@ -167,8 +166,8 @@ bool ObjectSupportSegmentation::segment(
     extract.setNegative(true);
     extract.filter(*cloud_filtered);
   }
-  ROS_DEBUG("object_support_segmentation",
-            "Cloud now %d points.", static_cast<int>(cloud_filtered->points.size()));
+  ROS_DEBUG_NAMED("object_support_segmentation",
+                  "Cloud now %d points.", static_cast<int>(cloud_filtered->points.size()));
 
   // Add the non-horizontal planes back in
   *cloud_filtered += *non_horizontal_planes;
@@ -177,8 +176,8 @@ bool ObjectSupportSegmentation::segment(
   std::vector<pcl::PointIndices> clusters;
   extract_clusters_.setInputCloud(cloud_filtered);
   extract_clusters_.extract(clusters);
-  ROS_DEBUG("object_support_segmentation",
-            "Extracted %d clusters.", static_cast<int>(clusters.size()));
+  ROS_DEBUG_NAMED("object_support_segmentation",
+                  "Extracted %d clusters.", static_cast<int>(clusters.size()));
 
   extract_indices_.setInputCloud(cloud_filtered);
   for (size_t i= 0; i < clusters.size(); i++)
@@ -207,8 +206,8 @@ bool ObjectSupportSegmentation::segment(
 
     if (support_plane_index == -1)
     {
-      ROS_DEBUG("object_support_segmentation",
-                "No support plane found for object");
+      ROS_DEBUG_NAMED("object_support_segmentation",
+                      "No support plane found for object");
       continue;
     }
 
@@ -232,8 +231,8 @@ bool ObjectSupportSegmentation::segment(
 
     if (output_clouds)
     {
-      ROS_DEBUG("object_support_segmentation",
-                "Adding an object cluster of size %d.", static_cast<int>(new_cloud.points.size()));
+      ROS_DEBUG_NAMED("object_support_segmentation",
+                      "Adding an object cluster of size %d.", static_cast<int>(new_cloud.points.size()));
       float hue = (360.0 / clusters.size()) * i;
       colorizeCloud(new_cloud, hue);
       object_cloud += new_cloud;


### PR DESCRIPTION
- optionally enable continuous detection without requiring to call actions
- by default skip point cloud transformation and use sensor frame directly