### PR TITLE
remove VTK dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,10 +23,6 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>shape_msgs</build_depend>
   <build_depend>tf</build_depend>
-
-  <!-- Needed to work around https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=894656 on Debian Stretch -->
-  <build_depend>libvtk-qt</build_depend>
-  <run_depend>libvtk-qt</run_depend>
   
   <run_depend>actionlib</run_depend>
   <run_depend>geometry_msgs</run_depend>


### PR DESCRIPTION
Debian stretch really isn't a target anymore, and apparently now we have other issues by specifying this dependency